### PR TITLE
Minor fixes for MELPA packaging

### DIFF
--- a/pixie-mode.el
+++ b/pixie-mode.el
@@ -38,10 +38,11 @@
 (define-derived-mode pixie-mode clojure-mode "Pixie"
   "Major mode for editing Pixie code.
 \\{pixie-mode-map}"
-  (define-key pixie-mode-map "\C-x\C-e" 'inf-clojure-eval-last-sexp)
-  (setq-local inferior-lisp-program pixie-inf-lisp-command)
-  (setq-local inf-clojure-load-command "(load-file \"%s\")")
-  (setq-local inf-clojure-program "pixie-vm"))
+  (set (make-local-variable 'inferior-lisp-program) pixie-inf-lisp-command)
+  (set (make-local-variable 'inf-clojure-load-command) "(load-file \"%s\")")
+  (set (make-local-variable 'inf-clojure-program) "pixie-vm"))
+
+(define-key pixie-mode-map "\C-x\C-e" 'inf-clojure-eval-last-sexp)
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.pxi\\'" . pixie-mode))


### PR DESCRIPTION
- Avoid setq-local, which would require Emacs 24.3
- Don't modify the keymap every time the mode is started in a buffer

See https://github.com/milkypostman/melpa/pull/2427